### PR TITLE
[Bugfix] Unable to renew domain, add new function and refactor for domain expiry and renew when update triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ Local Installation
       use_sandbox = false
     }
     ```
+
+Why Custom Provider
+-------------------
+
+Namecheap does not support managing resources with Terraform.

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -18,8 +18,14 @@ Manage a domain in NameCheap
 ### Required
 
 - `domain` (String) Domain name to manage in NameCheap
+- `max_price` (Number) Maximum price of the purchase domain
+- `nameservers` (List of String) Nameservers for the domain
 
 ### Optional
 
 - `min_days_remaining` (Number) The minimum amount of days remaining on the expiration of a domain before a renewal is attempted. The default is `30`. A value of less than `0` means that the domain will never be renewed.
 - `purchase_years` (Number) Number of years to purchase and renew. The default is `1`. The value must greater than 0 and less than or equal to 10
+
+### Read-Only
+
+- `domain_remaining_days` (Number) Domain remaining days before expired.

--- a/namecheap/namecheap_domain.go
+++ b/namecheap/namecheap_domain.go
@@ -210,15 +210,15 @@ func (r *namecheapDomainResource) Update(ctx context.Context, req resource.Updat
 		Nameservers:      plan.Nameservers,
 	}
 
-	// Compute DomainRemainingDays based on the domain expiry date
-	expiry_date, err := r.getDomainExpiry(plan.Domain.ValueString())
+	// Compute domainRemainingDays based on the domain expiry date
+	domainRemainingDays, err := r.getDomainExpiry(plan.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.Append(err)
 		return
 	}
 
 	// Attempt to renew domain if the DomainRemainingDays is lesser or equal to MinDaysRemaining
-	if expiry_date <= plan.MinDaysRemaining.ValueInt64() {
+	if domainRemainingDays <= plan.MinDaysRemaining.ValueInt64() {
 		domain := plan.Domain.ValueString()
 		renewYear := plan.Years.ValueInt64()
 
@@ -257,12 +257,12 @@ func (r *namecheapDomainResource) Update(ctx context.Context, req resource.Updat
 		resp.Diagnostics.AddError("Set nameserver failed error ", _err.Error())
 	}
 
-	new_expiry_date, err := r.getDomainExpiry(plan.Domain.ValueString())
+	newDomainRemainingDays, err := r.getDomainExpiry(plan.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.Append(err)
 		return
 	}
-	state.DomainRemainingDays = types.Int64Value(new_expiry_date)
+	state.DomainRemainingDays = types.Int64Value(newDomainRemainingDays)
 
 	setStateDiags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(setStateDiags...)

--- a/namecheap/namecheap_domain.go
+++ b/namecheap/namecheap_domain.go
@@ -242,7 +242,7 @@ func (r *namecheapDomainResource) Update(ctx context.Context, req resource.Updat
 				return
 			}
 		default:
-			resp.Diagnostics.AddError("invalid mode value", newMode)
+			resp.Diagnostics.AddError("Invalid mode value", newMode)
 			return
 		}
 	}
@@ -283,7 +283,7 @@ func (r *namecheapDomainResource) Delete(ctx context.Context, req resource.Delet
 
 	domain := state.Domain.ValueString()
 	// Since domain can not be deleted in NameCheap, so we do nothing here but give a warning
-	msg := fmt.Sprintf("Since domain can not be deleted in NameCheap, %s still exist actually", domain)
+	msg := fmt.Sprintf("Since domain can not be deleted in NameCheap, [%s] still exist actually", domain)
 	tflog.Warn(ctx, msg)
 }
 

--- a/namecheap/namecheap_domain.go
+++ b/namecheap/namecheap_domain.go
@@ -257,6 +257,7 @@ func (r *namecheapDomainResource) Update(ctx context.Context, req resource.Updat
 		resp.Diagnostics.AddError("Set nameserver failed error ", _err.Error())
 	}
 
+	// Update state with the new expiry date
 	newDomainRemainingDays, err := r.getDomainExpiry(plan.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.Append(err)


### PR DESCRIPTION
Update namecheap_domain.go

- Add domain_remaining_days
- Compute for domain expiry and renew when conditions are fulfilled